### PR TITLE
[CA-1207] Consistent dev and prod payloads

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -242,8 +242,7 @@ function postShibbolethToken(envName) {
     }
 
     const sub = req.auth.google.sub
-    const payloadUsername = envName === 'dev' ?
-      payload['fake-era-commons-username'] : payload['eraCommonsUsername']
+    const payloadUsername = payload['eraCommonsUsername']
     const pairs = await ekvdb.getPairs(sub)
     await ekvdb.setValue(sub, pairs, 'linkedNihUsername', payloadUsername)
     const thirtyDaysInSeconds = 60 * 60 * 24 * 30


### PR DESCRIPTION
Ticket: [CA-1207](https://broadworkbench.atlassian.net/browse/CA-1207)
As a part of [CA-1048](https://broadworkbench.atlassian.net/browse/CA-1048), the payload returned by dev shibboleth was updated to be consistent with the prod payload. That change needs to be reflected in this service as well

Relevant Shibboleth PR https://github.com/broadinstitute/shibboleth-service-provider/pull/35